### PR TITLE
Optin option added

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ export default class ScriptsPlugin extends Plugin {
 
 		const defaultOptions = {
 			head: true,
-			body: true
+			body: true,
+			optin: false
 		};
 
 		this.options = {
@@ -35,7 +36,8 @@ export default class ScriptsPlugin extends Plugin {
 				? document.head
 				: document.body;
 
-		const scripts = arrayify(scope.querySelectorAll('script:not([data-swup-ignore-script])'));
+		const selector = this.options.optin ? 'script[data-swup-reload-script]' : 'script:not([data-swup-ignore-script])';
+		const scripts = arrayify(scope.querySelectorAll(selector));
 
 		scripts.forEach((script) => this.runScript(script));
 


### PR DESCRIPTION
If the default optin:false is changed to true, then the script will reload only scripts with "data-swup-reload-script" attribute. Otherwise, the default opt-out behavior will reload every script the same as previously ignoring "data-swup-ignore-script" attributed scripts.

This is useful when using solutions like Google Tag Manager where you have zero control over how scripts are added to the page.